### PR TITLE
install.sh requires bash

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ shells over a peer-to-peer WireGuard connection. It's similar to
 ## Install
 
 ```bash
-curl -fsSL https://wush.dev/install.sh | sh
+curl -fsSL https://wush.dev/install.sh | bash
 ```
 
 For a manual installation, see the [latest release](https://github.com/coder/wush/releases/latest).


### PR DESCRIPTION
on a debian (dash) system:
```sh
curl -fsSL https://wush.dev/install.sh | sh
sh: 59: [[: not found
Downloading wush from https://github.com/coder/wush/releases/download/v0.1.2/wush_0.1.2_linux_amd64.tar.gz...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 14.3M  100 14.3M    0     0  4011k      0  0:00:03  0:00:03 --:--:-- 5462k
Extracting wush...
sh: 101: [: tar.gz: unexpected operator
sh: 103: [: tar.gz: unexpected operator
Unsupported file extension: tar.gz
```