### PR TITLE
trim spaces from auth token

### DIFF
--- a/cmd/wush/cp.go
+++ b/cmd/wush/cp.go
@@ -10,6 +10,7 @@ import (
 	"net/netip"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/charmbracelet/huh"
 	"github.com/coder/serpent"
@@ -54,7 +55,7 @@ func initAuth(authFlag *string, ca *overlay.ClientAuth) serpent.MiddlewareFunc {
 				}
 			}
 
-			err := ca.Parse(*authFlag)
+			err := ca.Parse(strings.TrimSpace(*authFlag))
 			if err != nil {
 				return fmt.Errorf("parse auth key: %w", err)
 			}


### PR DESCRIPTION
This is useful because sometimes on copy/pasting the token there is a leading or trailing space. This is more tolerant and accepts tokens that inadvertently have leading or trailing spaces.