### PR TITLE
Add option to specify DERP servers

### DIFF
--- a/tsserver/server.go
+++ b/tsserver/server.go
@@ -64,12 +64,7 @@ func DERPMapTailscale(ctx context.Context) (*tailcfg.DERPMap, error) {
 	return dm, nil
 }
 
-func NewServer(ctx context.Context, logger *slog.Logger, ov overlay.Overlay) (*server, error) {
-	dm, err := DERPMapTailscale(ctx)
-	if err != nil {
-		return nil, err
-	}
-
+func NewServer(ctx context.Context, logger *slog.Logger, ov overlay.Overlay, dm *tailcfg.DERPMap) (*server, error) {
 	s := &server{
 		logger:          logger,
 		noisePrivateKey: key.NewMachine(),


### PR DESCRIPTION
Allow users to specify a custom DERP configuration file via the `--derp-config-file` flag in multiple commands. This provides flexibility to use different DERP servers, enhancing connectivity options.

Closes https://github.com/coder/wush/issues/43