### PR TITLE
fix: prevent hanging on win11/arm64

### DIFF
--- a/cmd/wush/serve.go
+++ b/cmd/wush/serve.go
@@ -231,7 +231,7 @@ func newTSNet(direction string, verbose bool) (*tsnet.Server, error) {
 	srv.Hostname = "wush-" + direction
 	srv.Ephemeral = true
 	srv.AuthKey = direction
-	srv.ControlURL = "http://localhost:8080"
+	srv.ControlURL = "http://127.0.0.1:8080"
 	srv.Logf = func(format string, args ...any) {}
 	srv.UserLogf = func(format string, args ...any) {}
 	if verbose {

--- a/xssh/client.go
+++ b/xssh/client.go
@@ -27,7 +27,7 @@ func TailnetSSH(ctx context.Context, inv *serpent.Invocation, ts *tsnet.Server, 
 	// 	}
 	// }
 
-	sshConn, channels, requests, err := ssh.NewClientConn(conn, "localhost:22", &ssh.ClientConfig{
+	sshConn, channels, requests, err := ssh.NewClientConn(conn, "127.0.0.1:22", &ssh.ClientConfig{
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 	})
 	if err != nil {


### PR DESCRIPTION
Fixes https://github.com/coder/wush/issues/28

`localhost` was unable to be resolved, leading to the in-memory coordinator connections to break. This should've been `127.0.0.1` anyways since the DNS lookup is extraneous.